### PR TITLE
refactor: use async/await in MediaAttachmentsService

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Program",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "program": "${workspaceFolder}/src/main.ts",
+      "preLaunchTask": "tsc: build - tsconfig.build.json",
+      "console": "integratedTerminal",
+      "outFiles": [
+        "${workspaceFolder}/dist/**/*.js"
+      ]
+    }
+  ]
+}

--- a/sia-synchronizer/src/sia-synchronizer/entities/MediaAttachment.ts
+++ b/sia-synchronizer/src/sia-synchronizer/entities/MediaAttachment.ts
@@ -1,4 +1,4 @@
-import {Column, Entity, PrimaryColumn} from "typeorm";
+import {Column, Entity, PrimaryColumn, OneToOne, JoinColumn} from "typeorm";
 
 @Entity()
 export class MediaAttachment {
@@ -30,5 +30,21 @@ export class MediaAttachment {
     peerIp?: string;
 
     @Column({nullable: true})
-    peerWallet?: string
+    peerWallet?: string;
+
+    @OneToOne(() => MediaAttachment, {cascade: true, onDelete: "SET NULL", persistence: true})
+    @JoinColumn()
+    preview128?: MediaAttachment;
+
+    @OneToOne(() => MediaAttachment, {cascade: true, onDelete: "SET NULL", persistence: true})
+    @JoinColumn()
+    preview256?: MediaAttachment;
+
+    @OneToOne(() => MediaAttachment, {cascade: true, onDelete: "SET NULL", persistence: true})
+    @JoinColumn()
+    preview512?: MediaAttachment;
+
+    @OneToOne(() => MediaAttachment, {cascade: true, onDelete: "SET NULL", persistence: true})
+    @JoinColumn()
+    preview1024?: MediaAttachment;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import {ValidationPipe} from "@nestjs/common";
 import bodyParser from "body-parser";
 import {AppModule} from "./AppModule";
 import {config as envConfig} from "./config";
+import { MediaAttachmentsService } from "./media-attachments/MediaAttachmentsService";
 
 async function bootstrap() {
     const app = await NestFactory.create(AppModule);
@@ -14,6 +15,10 @@ async function bootstrap() {
     app.useGlobalPipes(new ValidationPipe({transform: true}));
     app.enableCors();
     await app.listen(envConfig.IGNITE_API_PORT);
+
+    // you can remove this after the first run
+    const mediaAttachmentsService = app.get(MediaAttachmentsService)
+    await mediaAttachmentsService.generatePreviewsForExistingMediaAttachments()
 }
 
 bootstrap();

--- a/src/media-attachments/MediaAttachmentsMapper.ts
+++ b/src/media-attachments/MediaAttachmentsMapper.ts
@@ -7,6 +7,16 @@ import {config} from "../config";
 export class MediaAttachmentsMapper {
     public toMediaAttachmentResponse(mediaAttachment: MediaAttachment): MediaAttachmentResponse {
         return new MediaAttachmentResponse({
+            ...this.toMediaAttachmentResponseWithoutPreviews(mediaAttachment),
+            preview128: mediaAttachment.preview128 && this.toMediaAttachmentResponseWithoutPreviews(mediaAttachment.preview128),
+            preview256: mediaAttachment.preview256 && this.toMediaAttachmentResponseWithoutPreviews(mediaAttachment.preview256),
+            preview512: mediaAttachment.preview512 && this.toMediaAttachmentResponseWithoutPreviews(mediaAttachment.preview512),
+            preview1024: mediaAttachment.preview1024 && this.toMediaAttachmentResponseWithoutPreviews(mediaAttachment.preview1024),
+        })
+    }
+
+    private toMediaAttachmentResponseWithoutPreviews(mediaAttachment: MediaAttachment): MediaAttachmentResponse {
+        return new MediaAttachmentResponse({
             id: mediaAttachment.id,
             url: `${config.HOST}/api/v1/media/${mediaAttachment.name}`,
             type: "image",

--- a/src/media-attachments/MediaAttachmentsService.ts
+++ b/src/media-attachments/MediaAttachmentsService.ts
@@ -1,9 +1,9 @@
-import {HttpException, HttpStatus, Injectable} from "@nestjs/common";
+import {HttpException, HttpStatus, Injectable, BadRequestException} from "@nestjs/common";
 import {LoggerService} from "nest-logger";
 import {Response} from "express";
 import fileSystem from "fs";
 import path from "path";
-import graphicsMagic from "gm";
+import graphicsMagic, { Dimensions } from "gm";
 import FileTypeExtractor from "file-type";
 import uuid from "uuid/v4";
 import {MediaAttachmentsRepository} from "./MediaAttachmentsRepository";
@@ -12,6 +12,8 @@ import {MediaAttachment} from "./entities";
 import {MediaAttachmentsMapper} from "./MediaAttachmentsMapper";
 import {config} from "../config";
 import {SkynetClient} from "../skynet";
+import {exists} from "../utils/file-utils"
+import {promisify} from "util"
 
 const gm = graphicsMagic.subClass({imageMagick: true});
 
@@ -23,70 +25,58 @@ export class MediaAttachmentsService {
                 private readonly log: LoggerService) {
     }
 
-    public saveMediaAttachment(multipartFile: MultipartFile): Promise<MediaAttachmentResponse> {
-        return new Promise<MediaAttachmentResponse>(async (resolve, reject) => {
-            try {
-                const id = uuid();
-                const temporaryFilePath = path.join(config.MEDIA_ATTACHMENTS_DIRECTORY, `${id}.temporary`);
-                const fileDescriptor = fileSystem.openSync(temporaryFilePath, "w");
-                fileSystem.writeSync(fileDescriptor, multipartFile.buffer);
-                fileSystem.closeSync(fileDescriptor);
+    public async saveMediaAttachment(multipartFile: MultipartFile): Promise<MediaAttachmentResponse> {
+        const id = uuid();
+        const temporaryFilePath = path.join(config.MEDIA_ATTACHMENTS_DIRECTORY, `${id}.temporary`);
+        await fileSystem.promises.writeFile(temporaryFilePath, multipartFile.buffer)
 
-                const file = await FileTypeExtractor.fromBuffer(fileSystem.readFileSync(temporaryFilePath));
-                if (file.mime.startsWith("image")) {
-                    gm(temporaryFilePath)
-                        .size(async (error, size) => {
-                            if (error) {
-                                console.log(error);
-                                reject(error);
-                            }
+        const fileTypeResult = await FileTypeExtractor.fromBuffer(multipartFile.buffer);
 
-                            const permanentFilePath = path.join(config.MEDIA_ATTACHMENTS_DIRECTORY, `${id}.${file.ext}`);
-                            fileSystem.renameSync(temporaryFilePath, permanentFilePath);
+        if (!fileTypeResult.mime.startsWith("image")) {
+            throw new BadRequestException("file is not an image");
+        }
 
-                            const mediaAttachment: MediaAttachment = {
-                                id,
-                                format: file.ext,
-                                mimeType: file.mime,
-                                height: size.height,
-                                width: size.width,
-                                name: `${id}.${file.ext}`,
-                                siaLink: null
-                            };
-                            await this.mediaAttachmentRepository.save(mediaAttachment);
+        const size = await this.getImageSize(temporaryFilePath)
 
-                            if (config.ENABLE_UPLOADING_IMAGES_TO_SIA) {
-                                this.skynetClient.uploadFile(permanentFilePath)
-                                    .then(async siaLink => {
-                                        this.log.info(`Media attachment ${mediaAttachment.name} has been uploaded to SIA`);
-                                        this.log.debug(`Media attachment ${mediaAttachment.name} received ${siaLink} SIA link`);
-                                        mediaAttachment.siaLink = siaLink;
-                                        await this.mediaAttachmentRepository.save(mediaAttachment);
-                                    })
-                                    .catch(error => {
-                                        this.log.error(`Error occurred when tried to upload media attachment ${mediaAttachment.name} to SIA`);
-                                        console.log(error);
-                                    });
-                            }
+        const permanentFilePath = path.join(config.MEDIA_ATTACHMENTS_DIRECTORY, `${id}.${fileTypeResult.ext}`);
+        await fileSystem.promises.rename(temporaryFilePath, permanentFilePath)
 
-                            resolve(this.mediaAttachmentsMapper.toMediaAttachmentResponse(mediaAttachment));
-                        })
-                }
-            } catch (error) {
-                console.log(error);
-                reject(error);
-            }
-        })
+        const mediaAttachment: MediaAttachment = {
+            id,
+            format: fileTypeResult.ext,
+            mimeType: fileTypeResult.mime,
+            height: size.height,
+            width: size.width,
+            name: `${id}.${fileTypeResult.ext}`,
+            siaLink: null
+        };
+        await this.mediaAttachmentRepository.save(mediaAttachment);
+
+        if (config.ENABLE_UPLOADING_IMAGES_TO_SIA) {
+            // do not await, cuz the execution can take several seconds
+            this.skynetClient.uploadFile(permanentFilePath)
+                .then(async siaLink => {
+                    this.log.info(`Media attachment ${mediaAttachment.name} has been uploaded to SIA`);
+                    this.log.debug(`Media attachment ${mediaAttachment.name} received ${siaLink} SIA link`);
+                    mediaAttachment.siaLink = siaLink;
+                    await this.mediaAttachmentRepository.save(mediaAttachment);
+                })
+                .catch(error => {
+                    this.log.error(`Error occurred when tried to upload media attachment ${mediaAttachment.name} to SIA`);
+                    console.log(error);
+                });
+        }
+
+        return this.mediaAttachmentsMapper.toMediaAttachmentResponse(mediaAttachment);
     }
 
     public async getMediaAttachmentByName(name: string, response: Response): Promise<void> {
         const mediaAttachment = await this.mediaAttachmentRepository.findByName(name);
 
         if (!mediaAttachment) {
-            throw new HttpException(`Could not find ${name}`, HttpStatus.NOT_FOUND);
-        }
+            throw new HttpException(`Could not find ${name}`, HttpStatus.NOT_FOUND)   }
 
-        const fileExists = fileSystem.existsSync(path.join(config.MEDIA_ATTACHMENTS_DIRECTORY, name));
+        const fileExists = await exists(path.join(config.MEDIA_ATTACHMENTS_DIRECTORY, name));
 
         if (fileExists) {
             response.header("Content-Type", mediaAttachment.mimeType);
@@ -96,5 +86,11 @@ export class MediaAttachmentsService {
             response.header("Content-Type", mediaAttachment.mimeType);
             fileSystem.createReadStream(path.join(config.MEDIA_ATTACHMENTS_DIRECTORY, name)).pipe(response);
         }
+    }
+
+    private async getImageSize(imagePath: string): Promise<Dimensions> {
+        const gmState = gm(imagePath)
+
+        return promisify(gmState.size.bind(gmState))()
     }
 }

--- a/src/media-attachments/entities/MediaAttachment.ts
+++ b/src/media-attachments/entities/MediaAttachment.ts
@@ -1,4 +1,4 @@
-import {Column, Entity, PrimaryColumn} from "typeorm";
+import {Column, Entity, PrimaryColumn, OneToOne, JoinColumn} from "typeorm";
 
 @Entity()
 export class MediaAttachment {
@@ -30,5 +30,21 @@ export class MediaAttachment {
     peerIp?: string;
 
     @Column({nullable: true})
-    peerWallet?: string
+    peerWallet?: string;
+
+    @OneToOne(() => MediaAttachment, {cascade: true, onDelete: "SET NULL", persistence: true})
+    @JoinColumn()
+    preview128?: MediaAttachment;
+
+    @OneToOne(() => MediaAttachment, {cascade: true, onDelete: "SET NULL", persistence: true})
+    @JoinColumn()
+    preview256?: MediaAttachment;
+
+    @OneToOne(() => MediaAttachment, {cascade: true, onDelete: "SET NULL", persistence: true})
+    @JoinColumn()
+    preview512?: MediaAttachment;
+
+    @OneToOne(() => MediaAttachment, {cascade: true, onDelete: "SET NULL", persistence: true})
+    @JoinColumn()
+    preview1024?: MediaAttachment;
 }

--- a/src/media-attachments/types/MediaAttachmentResponse.ts
+++ b/src/media-attachments/types/MediaAttachmentResponse.ts
@@ -8,6 +8,10 @@ export class MediaAttachmentResponse {
         width?: number,
         height?: number
     };
+    preview128?: MediaAttachmentResponse;
+    preview256?: MediaAttachmentResponse;
+    preview512?: MediaAttachmentResponse;
+    preview1024?: MediaAttachmentResponse;
 
     constructor(object: MediaAttachmentResponse) {
         Object.assign(this, object);

--- a/src/utils/file-utils.ts
+++ b/src/utils/file-utils.ts
@@ -1,7 +1,12 @@
 import {lookup} from "mime-types";
+import fileSystem, { PathLike } from "fs"
 
 export const isImage = (fileExtension: string): boolean => {
     const mime = lookup(fileExtension);
 
     return typeof mime === "string" && mime.startsWith("image");
 };
+
+export const exists = (path: PathLike): Promise<boolean> => {
+    return fileSystem.promises.stat(path).then(() => true).catch(() => false)
+}


### PR DESCRIPTION
В этом PR буду оптимизировать картинки, делая для них превюшки.
Пока добавил коммит с небольшим рефакторингом. Перевел sync методы для работы с файловой системой на async чтобы блокировок не было. В результате код тоже сократился)
Так же добавил скрипт для создания превю для уже существующих картинок (`MediaAttachmentsService#generatePreviewsForExistingMediaAttachments`). Этот скрипт будет запускаться при запуске приложения, его можно удалить потом.